### PR TITLE
extended globbing version

### DIFF
--- a/source/.i3a/term_font_size
+++ b/source/.i3a/term_font_size
@@ -96,9 +96,9 @@ if type -P alacritty &> /dev/null; then
 		if [[ -r ${Configs[0]} ]]; then
 			while read -r; do
 				if [[ $FoundFonts == True ]]; then
-					if [[ $REPLY =~ ^(\ +size:\ +)([[:digit:]]+)$ ]]; then
-						Pre=${BASH_REMATCH[1]}
-						Now=${BASH_REMATCH[2]}
+					if [[ $REPLY == +( )*size:\ *+([0-9]) ]]; then
+						Pre=${REPLY%%+([0-9])}
+						Now=${REPLY##*+( )}
 						if [[ -n $Raise ]]; then
 							Output+=("$Pre$(( Now + Raise ))")
 						elif [[ -n $Lower ]]; then


### PR DESCRIPTION
while splitting font size and value, instead of splitting by spaces, try to target numbers with extended globbing. that way you'll preserve the number of spaces and only edit the actual values. i am not exactly sure this is what you wanted, i've seen the video and understood what you were trying to do, and converted all regex stuff into extended globbing and when i saw your benchmark test changes, it seemed you were trying to do the same thing as the changes i made, but again, not sure and my mind is asleep. if this wasn't the point, let me know and ill work on it with you. creating this pr just to show you what i did, not familiar with github tbh.